### PR TITLE
Post-release tweaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,18 @@ __Sections__
  - `Removed` for deprecated features removed in this release.
  - `Fixed` for any bug fixes.
 
- ## [1.0.0]
+## [1.0.1]
+
+### Added
+
+- Swift and linker flags to suppress application extensions API warning
+
+### Changed 
+
+- Swift tools version updated to 5.6
+- Main target name updated to a more friendly version
+
+## [1.0.0]
 
 ### Added
 

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.5
+// swift-tools-version:5.3
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.6
+// swift-tools-version:5.5
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.6
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -12,20 +12,26 @@ let package = Package(
         // Products define the executables and libraries a package produces, and make them visible to other packages.
         .library(
             name: "DependencyInjection",
-            targets: ["DependencyInjectionModule"]
+            targets: ["DependencyInjection"]
         ),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
         // Targets can depend on other targets in this package, and on products in packages this package depends on.
         .target(
-            name: "DependencyInjectionModule",
+            name: "DependencyInjection",
             dependencies: [],
-            path: "Sources"
+            path: "Sources",
+            swiftSettings: [
+                .define("APPLICATION_EXTENSION_API_ONLY=YES")
+            ],
+            linkerSettings: [
+                .unsafeFlags(["-Xlinker", "-no_application_extension"])
+            ]
         ),
         .testTarget(
             name: "DependencyInjectionTests",
-            dependencies: ["DependencyInjectionModule"],
+            dependencies: ["DependencyInjection"],
             path: "Tests"
         ),
     ]

--- a/Tests/Common/DITestCase.swift
+++ b/Tests/Common/DITestCase.swift
@@ -6,7 +6,7 @@
 //
 
 import XCTest
-import DependencyInjectionModule
+import DependencyInjection
 
 class DITestCase: XCTestCase {
     var container: Container!

--- a/Tests/Container/ArgumentTests.swift
+++ b/Tests/Container/ArgumentTests.swift
@@ -6,7 +6,7 @@
 //
 
 import XCTest
-import DependencyInjectionModule
+import DependencyInjection
 
 final class ContainerArgumentTests: DITestCase {
     func testRegistration() {

--- a/Tests/Container/AutoregistrationTests.swift
+++ b/Tests/Container/AutoregistrationTests.swift
@@ -6,7 +6,7 @@
 //
 
 import XCTest
-import DependencyInjectionModule
+import DependencyInjection
 
 final class AutoregistrationTests: DITestCase {
     func testSharedAutoRegistrationWithoutParameter() {

--- a/Tests/Container/AutoregistrationWithArgumentTest.swift
+++ b/Tests/Container/AutoregistrationWithArgumentTest.swift
@@ -6,7 +6,7 @@
 //
 
 import XCTest
-import DependencyInjectionModule
+import DependencyInjection
 
 final class AutoregistrationWithArgumentTest: DITestCase {
     func testRegistrationWithoutParameter() {

--- a/Tests/Container/BaseTests.swift
+++ b/Tests/Container/BaseTests.swift
@@ -6,7 +6,7 @@
 //
 
 import XCTest
-import DependencyInjectionModule
+import DependencyInjection
 
 final class BaseTests: DITestCase {
     func testAutoclosureDependency() {

--- a/Tests/Container/ComplexTests.swift
+++ b/Tests/Container/ComplexTests.swift
@@ -6,7 +6,7 @@
 //
 
 import XCTest
-import DependencyInjectionModule
+import DependencyInjection
 
 final class ComplexTests: DITestCase {
     func testCleanContainer() {

--- a/Tests/PropertyWrappers/PropertyWrapperTests.swift
+++ b/Tests/PropertyWrappers/PropertyWrapperTests.swift
@@ -6,7 +6,7 @@
 //
 
 import XCTest
-import DependencyInjectionModule
+import DependencyInjection
 
 final class PropertyWrapperTests: DITestCase {
     override func tearDown() {        


### PR DESCRIPTION
### Added

- Swift and linker flags to suppress application extensions API warning

### Changed 

- Swift tools version updated to 5.6
- Main target name updated to a more friendly version
