### PR TITLE
Fix warning

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -23,7 +23,7 @@ let package = Package(
             dependencies: [],
             path: "Sources",
             swiftSettings: [
-                .define("APPLICATION_EXTENSION_API_ONLY=YES")
+                .define("APPLICATION_EXTENSION_API_ONLY")
             ]
         ),
         .testTarget(

--- a/Sources/Container/Container.swift
+++ b/Sources/Container/Container.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// Dependency Injection Container where dependencies are registered and from where they are consequently retrieved (i.e. resolved)
-open class Container {
+open class Container: DependencyWithArgumentAutoregistering, DependencyAutoregistering, DependencyWithArgumentResolving {
     /// Shared singleton
     public static let shared: Container = {
         Container()
@@ -31,10 +31,9 @@ open class Container {
     open func releaseSharedInstances() {
         sharedInstances.removeAll()
     }
-}
 
-// MARK: Register, Autoregister
-extension Container: DependencyAutoregistering {
+    // MARK: Register dependency, Autoregister dependency
+
     /// Register a dependency
     ///
     /// - Parameters:
@@ -50,10 +49,9 @@ extension Container: DependencyAutoregistering {
         // because the new registered factory most likely returns different objects and we have no way to tell
         sharedInstances[registration.identifier] = nil
     }
-}
 
-// MARK: Register with argument, Autoregister with argument
-extension Container: DependencyWithArgumentAutoregistering {
+    // MARK: Register dependency with argument, Autoregister dependency with argument
+
     /// Register a dependency with an argument
     ///
     /// The argument is typically a parameter in an initiliazer of the dependency that is not registered in the same container,
@@ -73,10 +71,9 @@ extension Container: DependencyWithArgumentAutoregistering {
         
         registrations[registration.identifier] = registration
     }
-}
 
-// MARK: Resolve
-extension Container: DependencyWithArgumentResolving {
+    // MARK: Resolve dependency
+
     /// Resolve a dependency that was previously registered with `register` method
     ///
     /// If a dependency of the given type with the given argument wasn't registered before this method call


### PR DESCRIPTION
This PR should fix the following warning:

![Screenshot 2022-10-04 at 17 53 59](https://user-images.githubusercontent.com/23376008/193870571-99743a26-d5df-419b-8110-f129da491132.png)
```
warning build: Conditional compilation flags do not have values in Swift; they are either present or absent (rather than 'APPLICATION_EXTENSION_API_ONLY=YES')
```

[GitHub search for APPLICATION_EXTENSION_API_ONLY in Package files](https://github.com/search?l=&p=1&q=define+APPLICATION_EXTENSION_API_ONLY+extension%3Aswift+filename%3Apackage&ref=advsearch&type=Code)