### PR TITLE
Create InjectedObservableObject

### DIFF
--- a/Sources/PropertyWrappers/InjectedObservedObject.swift
+++ b/Sources/PropertyWrappers/InjectedObservedObject.swift
@@ -1,0 +1,14 @@
+import SwiftUI
+
+@propertyWrapper public struct InjectedObservedObject<Object>: DynamicProperty
+where Object: ObservableObject {
+    @ObservedObject public var wrappedValue: Object = Container.shared.resolve()
+
+    public var projectedValue: ObservedObject<Object>.Wrapper {
+        $wrappedValue
+    }
+
+    public init(from container: Container = .shared) {
+        wrappedValue = container.resolve(type: Object.self)
+    }
+}


### PR DESCRIPTION
Hey STRV fellow engineers!

I've been thinking about using your super-duper tool also to SwiftUI's viewModels, dataModes, etc. In order to keep invalidating the view and re-render I had to create this special property wrapper. This way I can have both the benefits of using dependency injection and the `ObservableObject - (Observed|State)Object` relationship. 

Please let me know your thoughts about this. Thank you!

# Todos

- [ ] document properly 
- [ ] test properly